### PR TITLE
💄 Name以外の項目を表示、スタイリングしました。

### DIFF
--- a/src/components/Workshops.jsx
+++ b/src/components/Workshops.jsx
@@ -40,14 +40,6 @@ const StyledWorkshopTitle = styled.h3`
   font-size: 1rem;
   color: var(--main-fg-color);
 `;
-const StyledWorkshopSpan = styled.span`
-  display: inline-block;
-  padding: 3px 6px;
-  margin-right: 2px;
-  background-color: #c9cc10;
-  color: #fff;
-  border-radius: 10px;
-`;
 
 const workshopsEndpoint = "./.netlify/functions/workshops";
 
@@ -80,15 +72,6 @@ const Workshops = () => {
               <StyledWorkshopDetail>
                 <div>開催日：{workshop.fields.Date}</div>
                 <div>{workshop.fields.Notes}</div>
-                <StyledWorkshopSpan>
-                  {workshop.fields.Tag[0]}
-                </StyledWorkshopSpan>
-                <StyledWorkshopSpan>
-                  {!workshop.fields.Tag[1] ? null : workshop.fields.Tag[1]}
-                </StyledWorkshopSpan>
-                <StyledWorkshopSpan>
-                  {!workshop.fields.Tag[2] ? null : workshop.fields.Tag[2]}
-                </StyledWorkshopSpan>
               </StyledWorkshopDetail>
             </StyledWorkshop>
           ))}

--- a/src/components/Workshops.jsx
+++ b/src/components/Workshops.jsx
@@ -12,14 +12,35 @@ const StyledWorkshops = styled.section`
 `;
 
 const StyledWorkshop = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   font-size: 0.8rem;
   padding: 5px;
   background-color: #fff;
   border-radius: 3px;
   box-shadow: 10px 10px 22px -13px rgba(0, 0, 0, 0.8);
 `;
+const DivWrapper = styled.div`
+  margin-top: 3px;
+  padding: 3px;
+  font-size: 0.8rem;
+`;
+const H3 = styled.div`
+  padding: 3px;
+  font-size: 1rem;
+  color: rgb(132, 134, 6);
+`;
+const SpanWrapper = styled.span`
+  display: inline-block;
+  padding: 3px 6px;
+  margin-right:2px;
+  background-color: #c9cc10;
+  color: #fff;
+  border-radius: 10px;
+`;
 
-const workshopsEndpoint = './.netlify/functions/workshops';
+const workshopsEndpoint = "./.netlify/functions/workshops";
 
 const fetcher = (...args) => fetch(...args).then((res) => res.json());
 
@@ -46,7 +67,19 @@ const Workshops = () => {
         <StyledWorkshops>
           {workshops.map((workshop) => (
             <StyledWorkshop key={workshop.id}>
-              {workshop.fields.Name}
+              <H3>{workshop.fields.Name}</H3>
+              <DivWrapper>
+                <div>開催日：{workshop.fields.Date}</div>
+                <div>{workshop.fields.Notes}</div>
+                <SpanWrapper>{workshop.fields.Tag[0]}
+                </SpanWrapper>
+                <SpanWrapper>
+                  {!workshop.fields.Tag[1] ? null : workshop.fields.Tag[1]}
+                </SpanWrapper>
+                <SpanWrapper>
+                  {!workshop.fields.Tag[2] ? null : workshop.fields.Tag[2]}
+                </SpanWrapper>
+              </DivWrapper>
             </StyledWorkshop>
           ))}
         </StyledWorkshops>

--- a/src/components/Workshops.jsx
+++ b/src/components/Workshops.jsx
@@ -21,20 +21,20 @@ const StyledWorkshop = styled.div`
   border-radius: 3px;
   box-shadow: 10px 10px 22px -13px rgba(0, 0, 0, 0.8);
 `;
-const DivWrapper = styled.div`
+const StyledWorkshopDetail = styled.div`
   margin-top: 3px;
   padding: 3px;
   font-size: 0.8rem;
 `;
-const H3 = styled.div`
+const StyledWorkshopTitle = styled.h3`
   padding: 3px;
   font-size: 1rem;
   color: rgb(132, 134, 6);
 `;
-const SpanWrapper = styled.span`
+const StyledWorkshopSpan = styled.span`
   display: inline-block;
   padding: 3px 6px;
-  margin-right:2px;
+  margin-right: 2px;
   background-color: #c9cc10;
   color: #fff;
   border-radius: 10px;
@@ -67,19 +67,20 @@ const Workshops = () => {
         <StyledWorkshops>
           {workshops.map((workshop) => (
             <StyledWorkshop key={workshop.id}>
-              <H3>{workshop.fields.Name}</H3>
-              <DivWrapper>
+              <StyledWorkshopTitle>{workshop.fields.Name}</StyledWorkshopTitle>
+              <StyledWorkshopDetail>
                 <div>開催日：{workshop.fields.Date}</div>
                 <div>{workshop.fields.Notes}</div>
-                <SpanWrapper>{workshop.fields.Tag[0]}
-                </SpanWrapper>
-                <SpanWrapper>
+                <StyledWorkshopSpan>
+                  {workshop.fields.Tag[0]}
+                </StyledWorkshopSpan>
+                <StyledWorkshopSpan>
                   {!workshop.fields.Tag[1] ? null : workshop.fields.Tag[1]}
-                </SpanWrapper>
-                <SpanWrapper>
+                </StyledWorkshopSpan>
+                <StyledWorkshopSpan>
                   {!workshop.fields.Tag[2] ? null : workshop.fields.Tag[2]}
-                </SpanWrapper>
-              </DivWrapper>
+                </StyledWorkshopSpan>
+              </StyledWorkshopDetail>
             </StyledWorkshop>
           ))}
         </StyledWorkshops>

--- a/src/components/Workshops.jsx
+++ b/src/components/Workshops.jsx
@@ -25,7 +25,7 @@ const StyledWorkshop = styled.div`
   justify-content: space-between;
   font-size: 0.8rem;
   padding: 5px;
-  background-color: #fff;
+  background-color: var(--card-bg-color);
   border-radius: 3px;
   box-shadow: 10px 10px 22px -13px rgba(0, 0, 0, 0.8);
 `;
@@ -33,11 +33,12 @@ const StyledWorkshopDetail = styled.div`
   margin-top: 3px;
   padding: 3px;
   font-size: 0.8rem;
+  color: var(--main-fg-color);
 `;
 const StyledWorkshopTitle = styled.h3`
   padding: 3px;
   font-size: 1rem;
-  color: rgb(132, 134, 6);
+  color: var(--main-fg-color);
 `;
 const StyledWorkshopSpan = styled.span`
   display: inline-block;

--- a/src/components/Workshops.jsx
+++ b/src/components/Workshops.jsx
@@ -7,8 +7,16 @@ import { StyledError } from '../styled/StyledError';
 const StyledWorkshops = styled.section`
   display: grid;
   gap: 10px;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: repeat(3, 1fr);
   max-width: 1200px;
+  @media screen and (max-width: 1200px) {
+    grid-template-columns: repeat(2, 1fr);
+    max-width: 600px;
+    @media screen and (max-width: 600px) {
+      grid-template-columns: 1fr;
+      max-width: 350px;
+    }
+  }
 `;
 
 const StyledWorkshop = styled.div`

--- a/src/pages/WorkshopPage.jsx
+++ b/src/pages/WorkshopPage.jsx
@@ -1,17 +1,6 @@
-import React from 'react';
-import styled from 'styled-components';
-import { StyledPageTitle } from '../styled/StyledPageTitle';
-import Workshops from '../components/Workshops';
-
-// const StyledWorkshop = styled.div`
-//   height: 80vh;
-//   width: 70vw;
-//   max-width: 800px;
-//   display: grid;
-//   grid-template-rows: 50px 1fr;
-//   font-size: 1.5rem;
-//   gap: 2rem;
-// `;
+import React from "react";
+import { StyledPageTitle } from "../styled/StyledPageTitle";
+import Workshops from "../components/Workshops";
 
 const WorkshopPage = () => {
   return (
@@ -19,7 +8,7 @@ const WorkshopPage = () => {
       <StyledPageTitle>勉強会について</StyledPageTitle>
       <main>
         <p>これまで開催した勉強会資料は以下の通り。</p>
-        <Workshops/>
+        <Workshops />
       </main>
     </div>
   );

--- a/src/pages/WorkshopPage.jsx
+++ b/src/pages/WorkshopPage.jsx
@@ -3,25 +3,25 @@ import styled from 'styled-components';
 import { StyledPageTitle } from '../styled/StyledPageTitle';
 import Workshops from '../components/Workshops';
 
-const StyledWorkshop = styled.div`
-  height: 80vh;
-  width: 70vw;
-  max-width: 800px;
-  display: grid;
-  grid-template-rows: 50px 1fr;
-  font-size: 1.5rem;
-  gap: 2rem;
-`;
+// const StyledWorkshop = styled.div`
+//   height: 80vh;
+//   width: 70vw;
+//   max-width: 800px;
+//   display: grid;
+//   grid-template-rows: 50px 1fr;
+//   font-size: 1.5rem;
+//   gap: 2rem;
+// `;
 
 const WorkshopPage = () => {
   return (
-    <StyledWorkshop>
+    <div>
       <StyledPageTitle>勉強会について</StyledPageTitle>
       <main>
         <p>これまで開催した勉強会資料は以下の通り。</p>
         <Workshops/>
       </main>
-    </StyledWorkshop>
+    </div>
   );
 };
 


### PR DESCRIPTION
AirTableにスペースなどが混入していると考えられます。
<img width="105" alt="スクリーンショット 2021-11-16 17 39 00" src="https://user-images.githubusercontent.com/61738591/141951542-ce1e748f-f054-4818-ba07-ee6a06dee46f.png">

タグの表示の出し分けはベタな記述なので、プログラミング的に処理いただけるとありがたいです。
